### PR TITLE
Fix null item handling to prevent world join crash

### DIFF
--- a/src/core/config.hpp
+++ b/src/core/config.hpp
@@ -10,7 +10,7 @@ public:
     };
 
     struct ClientConfig {
-        std::string game_version{ "5.39" };
+        std::string game_version{ "5.51" };
         int protocol{ 225 };
         std::string dns_server{ "cloudflare" };
     };

--- a/src/core/handlers/connection_handler.cpp
+++ b/src/core/handlers/connection_handler.cpp
@@ -212,7 +212,7 @@ void ConnectionHandler::setup_on_super_main_start_handler()
 
             // ReSharper disable once CppVariableCanBeMadeConstexpr
             const std::string cache_path{ "resources/items.dat" };
-            const auto server_hash{ static_cast<std::uint32_t>(pkt->item_hash) };
+            const auto server_hash{ static_cast<std::int32_t>(pkt->item_hash) };
             const auto cached_hash{ (utils::hash::proton_file(cache_path)) };
 
             if (server_hash != cached_hash) {

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -30,8 +30,8 @@ WebServer::WebServer(
         return;
     }
 
-    dispatcher_.appendListener(event::Type::ClientConnect, [this](const event::Event& e) { on_client_connect(e); });
-    dispatcher_.appendListener(event::Type::ClientDisconnect, [this](const event::Event& e) { on_client_disconnect(e); });
+    dispatcher_.append_listener(event::Type::ClientConnect, [this](const event::Event& e) { on_client_connect(e); });
+    dispatcher_.append_listener(event::Type::ClientDisconnect, [this](const event::Event& e) { on_client_disconnect(e); });
 
     spdlog::info("HTTPS server listening on port 443");
     server_thread_ = std::thread{ &WebServer::listen_internal, this };

--- a/src/event/event.hpp
+++ b/src/event/event.hpp
@@ -156,10 +156,10 @@ struct TypedPacketEvent : Event {
     }
 };
 
-
 struct EventPolicies {
-    static Type get_event(const Event& e) { return e.type; }
-    static bool can_continue_invoking(const Event& e) { return !e.canceled; }
+    // @note error C2440
+    static Type getEvent(const Event& e) { return e.type; }
+    static bool canContinueInvoking(const Event& e) { return !e.canceled; }
 };
 
 using BaseDispatcher = eventpp::EventDispatcher<

--- a/src/packet/game/server.hpp
+++ b/src/packet/game/server.hpp
@@ -24,7 +24,7 @@ struct OnSendToServer : VariantPacket<PacketId::OnSendToServer> {
     std::string address;
     std::string door_id;
     std::string uuid_token;
-    uint8_t login_mode;
+    int8_t login_mode;
     std::string username;
 
     bool read(const Payload& payload) override
@@ -55,7 +55,7 @@ struct OnSendToServer : VariantPacket<PacketId::OnSendToServer> {
         door_id = text_parse.get(key, 0);
         uuid_token = text_parse.get(key, 1);
 
-        login_mode = variant.get<uint32_t>(5);
+        login_mode = variant.get<int32_t>(5);
         username = variant.get<std::string>(6);
         return true;
     }
@@ -71,7 +71,7 @@ struct OnSendToServer : VariantPacket<PacketId::OnSendToServer> {
             token,
             user,
             text_parse.get_raw(),
-            static_cast<uint32_t>(login_mode),
+            static_cast<int32_t>(login_mode),
             username
         };
         return VariantPayload{ game_packet, variant };
@@ -79,10 +79,11 @@ struct OnSendToServer : VariantPacket<PacketId::OnSendToServer> {
 };
 
 struct OnSuperMainStartAcceptLogonHrdxs47254722215a : VariantPacket<PacketId::OnSuperMainStartAcceptLogonHrdxs47254722215a> {
-    int32_t item_hash;
+    uint32_t item_hash;
     std::string u;
     std::string uu;
     std::string uuu;
+    std::string uuuu;
     uint32_t player_tribute_hash;
 
     bool read(const Payload& payload) override
@@ -99,11 +100,12 @@ struct OnSuperMainStartAcceptLogonHrdxs47254722215a : VariantPacket<PacketId::On
             return false;
         }
 
-        item_hash = variant.get<int32_t>(1);
+        item_hash = variant.get<uint32_t>(1);
         u = variant.get<std::string>(2);
         uu = variant.get<std::string>(3);
         uuu = variant.get<std::string>(4);
-        player_tribute_hash = variant.get<uint32_t>(5);
+        uuuu = variant.get<std::string>(5);
+        player_tribute_hash = variant.get<uint32_t>(6);
 
         return true;
     }
@@ -116,6 +118,7 @@ struct OnSuperMainStartAcceptLogonHrdxs47254722215a : VariantPacket<PacketId::On
             u,
             uu,
             uuu,
+            uuuu,
             player_tribute_hash
         };
         return VariantPayload{ game_packet, variant };

--- a/src/scripting/script_event_bridge.cpp
+++ b/src/scripting/script_event_bridge.cpp
@@ -118,7 +118,7 @@ ScriptEventBridge::ScriptEventBridge(
 ScriptEventBridge::~ScriptEventBridge()
 {
     for (auto& [type, handle] : event_handles_) {
-        dispatcher_.removeListener(type, handle);
+        dispatcher_.remove_listener(type, handle);
     }
 }
 
@@ -220,7 +220,7 @@ void ScriptEventBridge::setup_event_listeners()
     for (const auto type : event_values) {
         if (type == event::Type::Max) continue;
 
-        event_handles_[type] = dispatcher_.appendListener(
+        event_handles_[type] = dispatcher_.append_listener(
             type,
             make_handler(type),
             event::Priority::FairlyHigh
@@ -229,7 +229,7 @@ void ScriptEventBridge::setup_event_listeners()
 
     for (const auto& [name, pid] : PACKET_ID_MAP) {
         const auto type = event::packet_event_type(pid);
-        event_handles_[type] = dispatcher_.appendListener(
+        event_handles_[type] = dispatcher_.append_listener(
             type,
             make_handler(type),
             event::Priority::FairlyHigh

--- a/src/world/tile.hpp
+++ b/src/world/tile.hpp
@@ -85,11 +85,17 @@ struct Tile {
     [[nodiscard]] static bool idiot_growtopia_dev(const std::uint16_t fg, const std::uint16_t bg)
     {
         const auto item_database{ &item::ItemDatabase::instance() };
+        const auto* item_info{ item_database->get_item(fg) };
+
+        if (!item_info) {
+            return false;
+        }
+
         return (
-            item_database->get_item(fg)->item_type == item::ItemType::Lock ||
-            item_database->get_item(fg)->item_type == item::ItemType::Door ||
-            item_database->get_item(fg)->item_type == item::ItemType::Vending ||
-            item_database->get_item(fg)->item_type == item::ItemType::DisplayBlock
+            item_info->item_type == item::ItemType::Lock ||
+            item_info->item_type == item::ItemType::Door ||
+            item_info->item_type == item::ItemType::Vending ||
+            item_info->item_type == item::ItemType::DisplayBlock
         );
     }
 


### PR DESCRIPTION
Fixed a crash when joining a world caused by an unhandled exception from `ItemDatabase::get_item()` returning `nullptr`.

Fixes #97 and #98